### PR TITLE
Make waffle's tooltip adaptive

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@ant-design/icons": "4.0.0",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.3.0",
+    "@floating-ui/react-dom": "^1.0.1",
     "@google-cloud/local-auth": "^1.0.0",
     "@wevisdemo/ui": "^5.2.0",
     "autosuggest-highlight": "^3.1.1",

--- a/src/components/peopleAvatar.js
+++ b/src/components/peopleAvatar.js
@@ -34,6 +34,7 @@ const PeopleAvatar = ({ title = "", name, lastname }) => {
     <GatsbyImage
       image={getImage((personImageNode || placeHolderImageNode).node)}
       alt={alt}
+      style={{ pointerEvents: "none" }}
     />
   ) : null
 }

--- a/src/components/peopleCard.js
+++ b/src/components/peopleCard.js
@@ -11,12 +11,10 @@ export const ProfilePicture = props => {
         borderRadius: 84,
         width: 84,
         height: 84,
-        float: "left",
         marginBottom: 0,
         marginRight: "2rem",
         border: "2px solid var(--cl-black)",
         background: "var(--cl-gray-2) no-repeat",
-        backgroundSize: "cover",
         overflow: "hidden",
       }}
     >

--- a/src/components/waffle.js
+++ b/src/components/waffle.js
@@ -1,5 +1,6 @@
-import React from "react"
+import React, { useState } from "react"
 import { chunk, groupBy } from "lodash"
+import { useFloating, shift } from "@floating-ui/react-dom"
 import PeopleCard from "./peopleCard"
 import PartyLogo from "./partyLogo"
 
@@ -22,10 +23,6 @@ let cellStyle = (color, borderColor, isCross = false) => ({
   "&:hover": {
     border: "2px solid var(--cl-black)",
   },
-  "&:hover .tooltip-text": {
-    display: "block",
-    zIndex: 10,
-  },
   ...(isCross && {
     border: "none",
     backgroundImage: `url(${cross})`,
@@ -35,54 +32,74 @@ let cellStyle = (color, borderColor, isCross = false) => ({
 })
 
 const tooltipTextStyle = {
-  display: "none",
   position: "absolute",
-  top: "5px",
-  left: "-2px",
   width: 350,
-  padding: 0,
   lineHeight: "1.8rem",
-  border: "none",
-  borderRadius: "0 5px 5px 5px",
-  backgroundColor: "transparent",
+  zIndex: 10,
 }
 
 const WaffleCell = ({ node, cellStyleProps }) => {
+  const [isWaffleCellHover, setIsWaffleCellHover] = useState(false)
+  const { x, y, reference, floating } = useFloating({
+    placement: "bottom-start",
+    strategy: "absolute",
+    middleware: [shift()],
+  })
+
   return (
-    <div
-      css={cellStyle(
-        cellStyleProps.color,
-        cellStyleProps.borderColor,
-        cellStyleProps.isCross
-      )}
-    >
-      <div className="tooltip-text" css={tooltipTextStyle}>
-        <PeopleCard
-          {...node}
-          css={{
-            padding: "1rem 1rem",
-            margin: 0,
-            alignItems: "center",
-            border: "2px solid var(--cl-black)",
-            ".card-info": {
-              ".card-name": {
-                fontSize: "1.8rem",
-                fontWeight: "bold",
-                fontFamily: "var(--ff-text)",
-              },
-              ".card-description": {
-                fontSize: "1.6rem",
-                fontFamily: "var(--ff-text)",
-              },
-            },
-            ".profile-picture": {
-              height: "5rem",
-              flexBasis: "5rem",
-            },
-          }}
-        ></PeopleCard>
+    <>
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+      <div
+        css={cellStyle(
+          cellStyleProps.color,
+          cellStyleProps.borderColor,
+          cellStyleProps.isCross
+        )}
+        ref={reference}
+        onMouseEnter={() => {
+          setIsWaffleCellHover(true)
+        }}
+        onMouseLeave={() => {
+          setIsWaffleCellHover(false)
+        }}
+      >
+        {isWaffleCellHover && (
+          <div
+            css={tooltipTextStyle}
+            ref={floating}
+            style={{
+              top: y ?? 0,
+              left: x ?? 0,
+            }}
+          >
+            <PeopleCard
+              {...node}
+              css={{
+                padding: "1rem 1rem",
+                margin: 0,
+                alignItems: "center",
+                border: "2px solid var(--cl-black)",
+                ".card-info": {
+                  ".card-name": {
+                    fontSize: "1.8rem",
+                    fontWeight: "bold",
+                    fontFamily: "var(--ff-text)",
+                  },
+                  ".card-description": {
+                    fontSize: "1.6rem",
+                    fontFamily: "var(--ff-text)",
+                  },
+                },
+                ".profile-picture": {
+                  height: "5rem",
+                  flexBasis: "5rem",
+                },
+              }}
+            ></PeopleCard>
+          </div>
+        )}
       </div>
-    </div>
+    </>
   )
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2303,6 +2303,25 @@
     lodash.isundefined "^3.0.1"
     lodash.uniq "^4.5.0"
 
+"@floating-ui/core@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.0.2.tgz#d06a66d3ad8214186eda2432ac8b8d81868a571f"
+  integrity sha512-Skfy0YS3NJ5nV9us0uuPN0HDk1Q4edljaOhRBJGDWs9EBa7ZVMYBHRFlhLvvmwEoaIM9BlH6QJFn9/uZg0bACg==
+
+"@floating-ui/dom@^1.0.5":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.0.7.tgz#9e8e6615ce03e5ebc6a4ae879640a199a366f86d"
+  integrity sha512-6RsqvCYe0AYWtsGvuWqCm7mZytnXAZCjWtsWu1Kg8dI3INvj/DbKlDsZO+mKSaQdPT12uxIW9W2dAWJkPx4Y5g==
+  dependencies:
+    "@floating-ui/core" "^1.0.2"
+
+"@floating-ui/react-dom@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-1.0.1.tgz#ee3524eab740b9380a00f4c2629a758093414325"
+  integrity sha512-UW0t1Gi8ikbDRr8cQPVcqIDMBwUEENe5V4wlHWdrJ5egFnRQFBV9JirauTBFI6S8sM1qFUC1i+qa3g87E6CLTw==
+  dependencies:
+    "@floating-ui/dom" "^1.0.5"
+
 "@gatsbyjs/reach-router@^1.3.6":
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/@gatsbyjs/reach-router/-/reach-router-1.3.7.tgz#d32029f2b4d91bb6977e7fd605237e3a5db20096"


### PR DESCRIPTION
In previous version, `<PeopleCard>` used in `<WaffleCell>` as a tooltip was simply styled using position absolute with `:hover`. However, when the tooltip is near the edge of the screen, it can overflow out the viewport.

![The tooltip overflowed the viewport](https://user-images.githubusercontent.com/7108662/203726481-1c2a7d9f-4b0f-4bde-b7f4-c86d5c6531fb.png)

In this change, I used the library [Floating UI](https://floating-ui.com/) (iirc it's tree-shakable version of Popper.js) to make the tooltip automatically align itself without overflowing the viewport. Ofc that in non-overflow tooltip, it will behave as same as before.

![The tooltip adjust itself to not overflow the viewport](https://user-images.githubusercontent.com/7108662/203727454-ddfa3302-7366-45f8-ac97-52acbace3f5d.png)