### PR TITLE
fix: NaN in voteLogLegend

### DIFF
--- a/src/components/senate/autocomplete.js
+++ b/src/components/senate/autocomplete.js
@@ -370,7 +370,7 @@ const AutoComplete = ({
           missing: _.get(voteGroup, "5.length", 0),
         }
         for (const item in vote) {
-          vote[item] = ((vote[item] / all_motion) * 100).toFixed(2)
+          vote[item] = (vote[item] / all_motion) * 100
           if (vote[item] === 0) {
             vote[item] = 0
           }
@@ -466,10 +466,8 @@ const AutoComplete = ({
       totalVotelogType.missing
 
     for (const item in select_by_government) {
-      select_by_government[item] = (
-        (select_by_government[item] / sumVoteGovernment) *
-        100
-      ).toFixed(2)
+      select_by_government[item] =
+        (select_by_government[item] / sumVoteGovernment) * 100
       if (select_by_government[item] === 0) {
         select_by_government[item] = 0
       }
@@ -477,10 +475,8 @@ const AutoComplete = ({
     setSelectByGovernment(select_by_government)
 
     for (const item in select_by_position) {
-      select_by_position[item] = (
-        (select_by_position[item] / sumVotePosition) *
-        100
-      ).toFixed(2)
+      select_by_position[item] =
+        (select_by_position[item] / sumVotePosition) * 100
       if (select_by_position[item] === 0) {
         select_by_position[item] = 0
       }
@@ -489,10 +485,7 @@ const AutoComplete = ({
     setSenatorType(select_by_position)
 
     for (const item in select_by_career) {
-      select_by_career[item] = (
-        (select_by_career[item] / sumVoteCareer) *
-        100
-      ).toFixed(2)
+      select_by_career[item] = (select_by_career[item] / sumVoteCareer) * 100
       if (select_by_career[item] === 0) {
         select_by_career[item] = 0
       }
@@ -500,10 +493,7 @@ const AutoComplete = ({
     setSelectByCareer(select_by_career)
 
     for (const item in totalVotelogType) {
-      totalVotelogType[item] = (
-        (totalVotelogType[item] / sumTotal) *
-        100
-      ).toFixed(2)
+      totalVotelogType[item] = (totalVotelogType[item] / sumTotal) * 100
       if (totalVotelogType[item] === 0) {
         totalVotelogType[item] = 0
       }

--- a/src/components/voteLogLegend.js
+++ b/src/components/voteLogLegend.js
@@ -90,7 +90,7 @@ const VoteLogLegend = ({
         {missing !== undefined ? (
           type === "group" ? (
             <>
-              <b style={{ margin: "0 0.3rem" }}></b> {approve}%
+              <b style={{ margin: "0 0.3rem" }}></b> {approve.toFixed(2)}%
             </>
           ) : type === "popup" ? (
             <>
@@ -98,7 +98,7 @@ const VoteLogLegend = ({
             </>
           ) : (
             <>
-              <b css={cssLegendSpace}>เห็นด้วย</b> {approve}%
+              <b css={cssLegendSpace}>เห็นด้วย</b> {approve.toFixed(2)}%
             </>
           )
         ) : (
@@ -118,7 +118,7 @@ const VoteLogLegend = ({
         {missing !== undefined ? (
           type === "group" ? (
             <>
-              <b style={{ margin: "0 0.3rem" }}></b> {disprove}%
+              <b style={{ margin: "0 0.3rem" }}></b> {disprove.toFixed(2)}%
             </>
           ) : type === "popup" ? (
             <>
@@ -126,7 +126,7 @@ const VoteLogLegend = ({
             </>
           ) : (
             <>
-              <b css={cssLegendSpace}>ไม่เห็นด้วย</b> {disprove}%
+              <b css={cssLegendSpace}>ไม่เห็นด้วย</b> {disprove.toFixed(2)}%
             </>
           )
         ) : (
@@ -150,7 +150,7 @@ const VoteLogLegend = ({
         {missing !== undefined ? (
           type === "group" ? (
             <>
-              <b style={{ margin: "0 0.3rem" }}></b> {abstained}%
+              <b style={{ margin: "0 0.3rem" }}></b> {abstained.toFixed(2)}%
             </>
           ) : type === "popup" ? (
             <>
@@ -158,7 +158,7 @@ const VoteLogLegend = ({
             </>
           ) : (
             <>
-              <b css={cssLegendSpace}>งดออกเสียง</b> {abstained}%
+              <b css={cssLegendSpace}>งดออกเสียง</b> {abstained.toFixed(2)}%
             </>
           )
         ) : (
@@ -182,7 +182,7 @@ const VoteLogLegend = ({
         {missing !== undefined ? (
           type === "group" ? (
             <>
-              <b style={{ margin: "0 0.3rem" }}></b> {absent}%
+              <b style={{ margin: "0 0.3rem" }}></b> {absent.toFixed(2)}%
             </>
           ) : type === "popup" ? (
             <>
@@ -190,7 +190,7 @@ const VoteLogLegend = ({
             </>
           ) : (
             <>
-              <b css={cssLegendSpace}>ไม่ลงมติ</b> {absent}%
+              <b css={cssLegendSpace}>ไม่ลงมติ</b> {absent.toFixed(2)}%
             </>
           )
         ) : (
@@ -199,42 +199,30 @@ const VoteLogLegend = ({
           </>
         )}
       </span>
-      <span css={cssLegendWrap({ missing, type })}>
-        <img
-          src={cross}
-          style={{
-            margin: "0",
-          }}
-          width="8"
-          height="8"
-          alt={
-            missing !== undefined
-              ? type === "group"
-                ? ""
-                : "ไม่ลงมติ"
-              : "ไม่เข้าประชุม"
-          }
-        />{" "}
-        {missing !== undefined ? (
-          type === "group" ? (
+      {missing === undefined && special !== undefined && (
+        <span css={cssLegendWrap({ missing, type })}>
+          <img
+            src={cross}
+            style={{
+              margin: "0",
+            }}
+            width="8"
+            height="8"
+            alt={
+              missing !== undefined
+                ? type === "group"
+                  ? ""
+                  : "ไม่ลงมติ"
+                : "ไม่เข้าประชุม"
+            }
+          />{" "}
+          {missing === undefined && (
             <>
-              <b style={{ margin: "0 0.3rem" }}></b> {special}%
+              ไม่เข้าประชุม <b>{special}</b>
             </>
-          ) : type === "popup" ? (
-            <>
-              <b style={{ margin: "0 1rem" }}>ไม่ลงมติ</b> {special}
-            </>
-          ) : (
-            <>
-              <b css={cssLegendSpace}>ไม่ลงมติ</b> {special}%
-            </>
-          )
-        ) : (
-          <>
-            ไม่เข้าประชุม <b>{special}</b>
-          </>
-        )}
-      </span>
+          )}
+        </span>
+      )}
       {missing !== undefined && (
         <span css={cssLegendWrap({ missing, type })}>
           <div
@@ -246,7 +234,7 @@ const VoteLogLegend = ({
           />{" "}
           {type === "group" ? (
             <>
-              <b style={{ margin: "0 0.3rem" }}></b> {missing}%
+              <b style={{ margin: "0 0.3rem" }}></b> {missing.toFixed(2)}%
             </>
           ) : type === "popup" ? (
             <>
@@ -254,7 +242,7 @@ const VoteLogLegend = ({
             </>
           ) : (
             <>
-              <b css={cssLegendSpace}>ขาด</b> {missing}%
+              <b css={cssLegendSpace}>ขาด</b> {missing.toFixed(2)}%
             </>
           )}
         </span>


### PR DESCRIPTION
Fixes issue #15 

I also fixed the `.toFixed(2)` that caused the summation of the string variable to be `NaN` and separate the computation (`calPercentLegend()`) from the presentation (jsx).

After working on the `voteLogLegend` shinanigans, I would recommend that `voteLogLegend` component should be split into 3 different components based on the locations used

- `autocomplete` component
- `voteLogCard` component
- `voteLog` page

IMO, the code would be a lot more maintainable if the `voteLogLegend` does not hold this much display logic.