### PR TITLE
fix: party description not display :bug:

### DIFF
--- a/src/templates/party-template.js
+++ b/src/templates/party-template.js
@@ -25,6 +25,7 @@ export const query = graphql`
       en {
         name
       }
+      description
       established_date
       dissolved_date
       color


### PR DESCRIPTION
Fixes issue #45

## Background
The graphQL query didn't contain the `description` property for partyYaml, that why the description is not displayed in `/party/ชื่อพรรค`. 

## Changes
- Add description property to `partyYaml` in graphQL query of `party-template.js`

## Screenshots
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/52349645/222744156-8ed0dcfd-d7ea-40f3-95f8-40d7370b1aec.png">
<img width="1440" alt="Screenshot 2566-03-03 at 21 21 07" src="https://user-images.githubusercontent.com/52349645/222744279-c7388289-f853-4ef2-9232-13f6d1a247ee.png">
