### PR TITLE
Refactor voteLogLegend by split by used component

### DIFF
--- a/src/components/quantityLegend.js
+++ b/src/components/quantityLegend.js
@@ -51,12 +51,12 @@ const QuantityLegend = ({
       )}{" "}
       {invertedBoldText ? (
         <span>
-          <b style={{ ...descTextStyle }}>{`${text} `}</b>
+          <b style={{ ...descTextStyle }}>{text ? `${text} ` : ""}</b>
           {quantityDisplayText()}
         </span>
       ) : (
         <span>
-          {`${text} `} <b>{quantityDisplayText()}</b>
+          {text ? `${text} ` : ""} <b>{quantityDisplayText()}</b>
         </span>
       )}
     </div>

--- a/src/components/quantityLegend.js
+++ b/src/components/quantityLegend.js
@@ -1,0 +1,31 @@
+import React from "react"
+
+// Item for vote log.
+// Should accept props for
+// - Legend box
+// - Text
+// - Count.
+// + Refactor to emotion
+const QuantityLegend = ({ text, quantity, isPercent, invertedBoldText }) => {
+  const quantityDisplayText = () => {
+    return isPercent ? `${quantity}%` : `${quantity}`
+  }
+
+  return (
+    <span>
+      <div>Box</div>
+      {invertedBoldText ? (
+        <>
+          <b>{text}</b>
+          {quantityDisplayText()}
+        </>
+      ) : (
+        <>
+          {text} <b>{quantityDisplayText()}</b>
+        </>
+      )}
+    </span>
+  )
+}
+
+export default QuantityLegend

--- a/src/components/quantityLegend.js
+++ b/src/components/quantityLegend.js
@@ -29,18 +29,29 @@ const LegendBox = styled.div`
 const QuantityLegend = ({
   text,
   boxSize,
+  imgSrc,
   background,
   quantity,
   isPercent,
   invertedBoldText,
 }) => {
-  const quantityDisplayText = () => {
-    return isPercent ? `${quantity}%` : `${quantity}`
-  }
+  const quantityDisplayText = () => (isPercent ? `${quantity}%` : `${quantity}`)
 
   return (
     <LegendWrap>
-      <LegendBox size={boxSize} background={background} />{" "}
+      {imgSrc ? (
+        <img
+          src={imgSrc}
+          width={boxSize}
+          height={boxSize}
+          style={{
+            marginRight: "4px",
+          }}
+          alt={text}
+        />
+      ) : (
+        <LegendBox size={boxSize} background={background} />
+      )}{" "}
       {invertedBoldText ? (
         <span>
           <b>{text}</b>

--- a/src/components/quantityLegend.js
+++ b/src/components/quantityLegend.js
@@ -1,18 +1,11 @@
 import styled from "@emotion/styled"
 import React from "react"
 
-// Item for vote log.
-// Should accept props for
-// - Legend box
-// - Text
-// - Count.
-// + Refactor to emotion
 const LegendWrap = styled.span`
   margin-right: 1rem;
   display: flex;
   align-items: baseline;
   font-size: unset;
-  margin-top: 0.6rem;
   white-space: nowrap;
 `
 

--- a/src/components/quantityLegend.js
+++ b/src/components/quantityLegend.js
@@ -12,7 +12,7 @@ const QuantityLegend = ({
   boxStyle,
   descTextStyle,
 }) => {
-  const quantityDisplayText = () => (isPercent ? `${quantity}%` : `${quantity}`)
+  const quantityDisplayText = isPercent ? `${quantity}%` : `${quantity}`
 
   return (
     <div
@@ -51,12 +51,12 @@ const QuantityLegend = ({
       )}{" "}
       {invertedBoldText ? (
         <span>
-          <b style={{ ...descTextStyle }}>{text ? `${text} ` : ""}</b>
-          {quantityDisplayText()}
+          {text && <b style={{ ...descTextStyle }}>{text}</b>}
+          {quantityDisplayText}
         </span>
       ) : (
         <span>
-          {text ? `${text} ` : ""} <b>{quantityDisplayText()}</b>
+          {text ? `${text} ` : ""} <b>{quantityDisplayText}</b>
         </span>
       )}
     </div>

--- a/src/components/quantityLegend.js
+++ b/src/components/quantityLegend.js
@@ -1,3 +1,4 @@
+import styled from "@emotion/styled"
 import React from "react"
 
 // Item for vote log.
@@ -6,25 +7,51 @@ import React from "react"
 // - Text
 // - Count.
 // + Refactor to emotion
-const QuantityLegend = ({ text, quantity, isPercent, invertedBoldText }) => {
+const LegendWrap = styled.span`
+  margin-right: 1rem;
+  display: flex;
+  align-items: baseline;
+  font-size: unset;
+  margin-top: 0.6rem;
+  white-space: nowrap;
+`
+
+const LegendBox = styled.div`
+  display: inline-box;
+  box-sizing: border-box;
+  border: 1px solid ${props => props.background ?? "var(--cl-black)"};
+  background-color: ${props => props.background ?? "var(--cl-white)"};
+  width: ${props => props.size}px;
+  height: ${props => props.size}px;
+  margin-right: 4px;
+`
+
+const QuantityLegend = ({
+  text,
+  boxSize,
+  background,
+  quantity,
+  isPercent,
+  invertedBoldText,
+}) => {
   const quantityDisplayText = () => {
     return isPercent ? `${quantity}%` : `${quantity}`
   }
 
   return (
-    <span>
-      <div>Box</div>
+    <LegendWrap>
+      <LegendBox size={boxSize} background={background} />{" "}
       {invertedBoldText ? (
-        <>
+        <span>
           <b>{text}</b>
           {quantityDisplayText()}
-        </>
+        </span>
       ) : (
-        <>
+        <span>
           {text} <b>{quantityDisplayText()}</b>
-        </>
+        </span>
       )}
-    </span>
+    </LegendWrap>
   )
 }
 

--- a/src/components/quantityLegend.js
+++ b/src/components/quantityLegend.js
@@ -1,23 +1,4 @@
-import styled from "@emotion/styled"
 import React from "react"
-
-const LegendWrap = styled.span`
-  margin-right: 1rem;
-  display: flex;
-  align-items: baseline;
-  font-size: unset;
-  white-space: nowrap;
-`
-
-const LegendBox = styled.div`
-  display: inline-box;
-  box-sizing: border-box;
-  border: 1px solid ${props => props.background ?? "var(--cl-black)"};
-  background-color: ${props => props.background ?? "var(--cl-white)"};
-  width: ${props => props.size}px;
-  height: ${props => props.size}px;
-  margin-right: 4px;
-`
 
 const QuantityLegend = ({
   text,
@@ -27,11 +8,23 @@ const QuantityLegend = ({
   quantity,
   isPercent,
   invertedBoldText,
+  wrapStyle,
+  boxStyle,
+  descTextStyle,
 }) => {
   const quantityDisplayText = () => (isPercent ? `${quantity}%` : `${quantity}`)
 
   return (
-    <LegendWrap>
+    <div
+      css={{
+        marginRight: "1rem",
+        display: "flex",
+        alignItems: "baseline",
+        fontSize: "unset",
+        whiteSpace: "nowrap",
+        ...wrapStyle,
+      }}
+    >
       {imgSrc ? (
         <img
           src={imgSrc}
@@ -43,19 +36,30 @@ const QuantityLegend = ({
           alt={text}
         />
       ) : (
-        <LegendBox size={boxSize} background={background} />
+        <div
+          css={{
+            display: "inline-box",
+            boxSizing: "border-box",
+            border: `1px solid ${background ?? "var(--cl-black)"}`,
+            backgroundColor: `${background ?? "var(--cl-white)"}`,
+            marginRight: "4px",
+            width: boxSize,
+            height: boxSize,
+            ...boxStyle,
+          }}
+        />
       )}{" "}
       {invertedBoldText ? (
         <span>
-          <b>{text}</b>
+          <b style={{ ...descTextStyle }}>{`${text} `}</b>
           {quantityDisplayText()}
         </span>
       ) : (
         <span>
-          {text} <b>{quantityDisplayText()}</b>
+          {`${text} `} <b>{quantityDisplayText()}</b>
         </span>
       )}
-    </LegendWrap>
+    </div>
   )
 }
 

--- a/src/components/senate/autocomplete.js
+++ b/src/components/senate/autocomplete.js
@@ -10,7 +10,7 @@ import search from "../../images/icons/search/search-grey.png"
 import { media } from "../../styles"
 import _ from "lodash"
 import PeopleAvatar from "../peopleAvatar"
-import VoteLegendGroup from "../voteLegend/voteSenateGroup"
+import SenateVoteLegendGroup from "../voteLegend/senateVoteLegendGroup"
 
 const cssContainer = ({ isShowAll }) => ({
   display: "flex",
@@ -566,7 +566,7 @@ const AutoComplete = ({
             โดยเฉลี่ย
           </span>
           <div css={cssAvgVoteLegend}>
-            <VoteLegendGroup voteLog={avgVotelog} hasAverageText />
+            <SenateVoteLegendGroup voteLog={avgVotelog} hasAverageText />
           </div>
         </div>
       ) : (
@@ -577,7 +577,7 @@ const AutoComplete = ({
           >
             <span css={cssGroup}>โดยตำแหน่ง</span>
             <div css={cssVotelog}>
-              <VoteLegendGroup voteLog={select_by_position} isSmallText />
+              <SenateVoteLegendGroup voteLog={select_by_position} isSmallText />
             </div>
           </div>
           <div
@@ -586,13 +586,16 @@ const AutoComplete = ({
           >
             <span css={cssGroup}>คสช. สรรหา</span>
             <div css={cssVotelog}>
-              <VoteLegendGroup voteLog={select_by_government} isSmallText />
+              <SenateVoteLegendGroup
+                voteLog={select_by_government}
+                isSmallText
+              />
             </div>
           </div>
           <div css={cssTypeDetails} style={{ width: barchartGroupWidth[2] }}>
             <span css={cssGroup}>ตามกลุ่มอาชีพ</span>
             <div css={cssVotelog}>
-              <VoteLegendGroup voteLog={select_by_career} isSmallText />
+              <SenateVoteLegendGroup voteLog={select_by_career} isSmallText />
             </div>
           </div>
           <div css={cssDropdown}>

--- a/src/components/senate/autocomplete.js
+++ b/src/components/senate/autocomplete.js
@@ -10,6 +10,7 @@ import search from "../../images/icons/search/search-grey.png"
 import { media } from "../../styles"
 import _ from "lodash"
 import PeopleAvatar from "../peopleAvatar"
+import VoteLegendGroup from "../voteLegend/voteSenateGroup"
 
 const cssContainer = ({ isShowAll }) => ({
   display: "flex",
@@ -116,6 +117,14 @@ const cssClearIcon = {
   },
   "&:after": {
     transform: "rotate(-45deg)",
+  },
+}
+const cssAvgVoteLegend = {
+  display: "flex",
+  flexWrap: "wrap",
+  justifyContent: "center",
+  [media(767)]: {
+    justifyContent: "unset",
   },
 }
 const cssSearchIcon = {
@@ -455,9 +464,9 @@ const AutoComplete = ({
 
   const calLegend = () => {
     const numberType = _.groupBy(getAllPeopleVotes(), "senator_method")
-    const sumVoteGovernment = numberType["เลือกโดย คสช."].length
-    const sumVotePosition = numberType["โดยตำแหน่ง"].length
-    const sumVoteCareer = numberType["เลือกกันเอง"].length
+    const sumVoteGovernment = numberType["เลือกโดย คสช."]?.length ?? 0
+    const sumVotePosition = numberType["โดยตำแหน่ง"]?.length ?? 0
+    const sumVoteCareer = numberType["เลือกกันเอง"]?.length ?? 0
     const sumTotal =
       totalVotelogType.approve +
       totalVotelogType.disprove +
@@ -530,6 +539,7 @@ const AutoComplete = ({
 
   const colors = ["#76C8B8", "#F0324B", "#2D3480", "#7B90D1", "#E3E3E3"]
 
+  console.log(avgVotelog)
   return (
     <div css={cssContainer({ isShowAll })}>
       {isShowAll ? (
@@ -552,7 +562,9 @@ const AutoComplete = ({
           <span css={cssAvg} style={{ margin: "0 1.5rem" }}>
             โดยเฉลี่ย
           </span>
-          <VoteLogLegend {...avgVotelog} />
+          <div css={cssAvgVoteLegend}>
+            <VoteLegendGroup voteLog={avgVotelog} />
+          </div>
         </div>
       ) : (
         <div css={cssWrapper({ isShowAll })}>

--- a/src/components/senate/autocomplete.js
+++ b/src/components/senate/autocomplete.js
@@ -162,6 +162,10 @@ const cssMobile = {
     display: "none",
   },
 }
+const cssVotelog = {
+  display: "flex",
+  alignItems: "end",
+}
 
 const AutoComplete = ({
   senatorTypeId,
@@ -563,7 +567,7 @@ const AutoComplete = ({
             โดยเฉลี่ย
           </span>
           <div css={cssAvgVoteLegend}>
-            <VoteLegendGroup voteLog={avgVotelog} />
+            <VoteLegendGroup voteLog={avgVotelog} hasAverageText />
           </div>
         </div>
       ) : (
@@ -573,18 +577,24 @@ const AutoComplete = ({
             style={{ width: barchartGroupWidth[0] + 230 }}
           >
             <span css={cssGroup}>โดยตำแหน่ง</span>
-            <VoteLogLegend type="group" {...select_by_position} />
+            <div css={cssVotelog}>
+              <VoteLegendGroup voteLog={select_by_position} isSmallText />
+            </div>
           </div>
           <div
             css={cssTypeDetails}
             style={{ width: barchartGroupWidth[1] + 105 }}
           >
             <span css={cssGroup}>คสช. สรรหา</span>
-            <VoteLogLegend type="group" {...select_by_government} />
+            <div css={cssVotelog}>
+              <VoteLegendGroup voteLog={select_by_government} isSmallText />
+            </div>
           </div>
           <div css={cssTypeDetails} style={{ width: barchartGroupWidth[2] }}>
             <span css={cssGroup}>ตามกลุ่มอาชีพ</span>
-            <VoteLogLegend type="group" {...select_by_career} />
+            <div css={cssVotelog}>
+              <VoteLegendGroup voteLog={select_by_career} isSmallText />
+            </div>
           </div>
           <div css={cssDropdown}>
             <DropDown

--- a/src/components/senate/autocomplete.js
+++ b/src/components/senate/autocomplete.js
@@ -543,7 +543,6 @@ const AutoComplete = ({
 
   const colors = ["#76C8B8", "#F0324B", "#2D3480", "#7B90D1", "#E3E3E3"]
 
-  console.log(avgVotelog)
   return (
     <div css={cssContainer({ isShowAll })}>
       {isShowAll ? (

--- a/src/components/senate/voteInfoPopup.js
+++ b/src/components/senate/voteInfoPopup.js
@@ -1,10 +1,10 @@
 import React, { useEffect } from "react"
 import Waffle from "../waffle"
-import VoteLogLegend from "../voteLogLegend"
 import VoterList from "../voterList"
 import download from "../../images/icons/download/download.png"
 import _ from "lodash"
 import { media } from "../../styles"
+import VoteLegendPopupGroup from "../voteLegend/voteInfoPopupGroup"
 
 const cssPopupContainer = {
   position: "fixed",
@@ -241,8 +241,26 @@ const VoteInfoPopup = ({
                 `var(--cl-senate-vote-missing)`,
               ]}
             />
-            <div css={{ marginTop: "4rem" }}>
-              <VoteLogLegend type="popup" {...countVotelog} />
+            <div
+              css={{
+                display: "flex",
+                flexWrap: "wrap",
+                justifyContent: "center",
+                marginTop: "4rem",
+              }}
+            >
+              {/* <VoteLogLegend type="popup" {...countVotelog} /> */}
+              {/* <VoteLegendGroup
+                voteLog={countVotelog}
+                overrideBoxStyle={{
+                  [media(767)]: {
+                    width: "8px",
+                    height: "8px",
+                  },
+                }}
+                // isAverageCount={false}
+              /> */}
+              <VoteLegendPopupGroup voteLog={countVotelog} />
             </div>
           </section>
 

--- a/src/components/senate/voteInfoPopup.js
+++ b/src/components/senate/voteInfoPopup.js
@@ -249,17 +249,6 @@ const VoteInfoPopup = ({
                 marginTop: "4rem",
               }}
             >
-              {/* <VoteLogLegend type="popup" {...countVotelog} /> */}
-              {/* <VoteLegendGroup
-                voteLog={countVotelog}
-                overrideBoxStyle={{
-                  [media(767)]: {
-                    width: "8px",
-                    height: "8px",
-                  },
-                }}
-                // isAverageCount={false}
-              /> */}
               <VoteLegendPopupGroup voteLog={countVotelog} />
             </div>
           </section>

--- a/src/components/voteLegend/senateVoteLegendGroup.js
+++ b/src/components/voteLegend/senateVoteLegendGroup.js
@@ -54,7 +54,7 @@ const smallDescTextStyle = {
   marginRight: "0.7rem",
 }
 
-const VoteLegendGroup = ({ voteLog, hasAverageText, isSmallText }) => {
+const SenateVoteLegendGroup = ({ voteLog, hasAverageText, isSmallText }) => {
   return (
     <>
       {hasAverageText && <div css={styleAvgText}>โดยเฉลี่ย</div>}
@@ -112,4 +112,4 @@ const VoteLegendGroup = ({ voteLog, hasAverageText, isSmallText }) => {
   )
 }
 
-export default VoteLegendGroup
+export default SenateVoteLegendGroup

--- a/src/components/voteLegend/senateVoteLegendGroup.js
+++ b/src/components/voteLegend/senateVoteLegendGroup.js
@@ -64,7 +64,7 @@ const SenateVoteLegendGroup = ({ voteLog, hasAverageText, isSmallText }) => {
         boxStyle={isSmallText ? smallBoxStyle : boxStyle}
         descTextStyle={isSmallText ? smallDescTextStyle : descTextStyle}
         quantity={voteLog.approve}
-        background={"var(--cl-vote-yes)"}
+        background="var(--cl-vote-yes)"
         invertedBoldText
         isPercent
       />
@@ -74,7 +74,7 @@ const SenateVoteLegendGroup = ({ voteLog, hasAverageText, isSmallText }) => {
         boxStyle={isSmallText ? smallBoxStyle : boxStyle}
         descTextStyle={isSmallText ? smallDescTextStyle : descTextStyle}
         quantity={voteLog.disprove}
-        background={"var(--cl-vote-no)"}
+        background="var(--cl-vote-no)"
         invertedBoldText
         isPercent
       />
@@ -84,7 +84,7 @@ const SenateVoteLegendGroup = ({ voteLog, hasAverageText, isSmallText }) => {
         boxStyle={isSmallText ? smallBoxStyle : boxStyle}
         descTextStyle={isSmallText ? smallDescTextStyle : descTextStyle}
         quantity={voteLog.abstained}
-        background={"var(--cl-senate-vote-abstained)"}
+        background="var(--cl-senate-vote-abstained)"
         invertedBoldText
         isPercent
       />
@@ -94,7 +94,7 @@ const SenateVoteLegendGroup = ({ voteLog, hasAverageText, isSmallText }) => {
         boxStyle={isSmallText ? smallBoxStyle : boxStyle}
         descTextStyle={isSmallText ? smallDescTextStyle : descTextStyle}
         quantity={voteLog.absent}
-        background={"var(--cl-senate-vote-absent)"}
+        background="var(--cl-senate-vote-absent)"
         invertedBoldText
         isPercent
       />
@@ -104,7 +104,7 @@ const SenateVoteLegendGroup = ({ voteLog, hasAverageText, isSmallText }) => {
         boxStyle={isSmallText ? smallBoxStyle : boxStyle}
         descTextStyle={isSmallText ? smallDescTextStyle : descTextStyle}
         quantity={voteLog.missing}
-        background={"var(--cl-senate-vote-missing)"}
+        background="var(--cl-senate-vote-missing)"
         invertedBoldText
         isPercent
       />

--- a/src/components/voteLegend/voteInfoPopupGroup.js
+++ b/src/components/voteLegend/voteInfoPopupGroup.js
@@ -31,7 +31,7 @@ const VoteLegendPopupGroup = ({ voteLog }) => {
         boxStyle={boxStyle}
         descTextStyle={descTextStyle}
         quantity={voteLog.approve}
-        background={"var(--cl-vote-yes)"}
+        background="var(--cl-vote-yes)"
         invertedBoldText
       />
       <QuantityLegend
@@ -40,7 +40,7 @@ const VoteLegendPopupGroup = ({ voteLog }) => {
         boxStyle={boxStyle}
         descTextStyle={descTextStyle}
         quantity={voteLog.disprove}
-        background={"var(--cl-vote-no)"}
+        background="var(--cl-vote-no)"
         invertedBoldText
       />
       <QuantityLegend
@@ -49,7 +49,7 @@ const VoteLegendPopupGroup = ({ voteLog }) => {
         boxStyle={boxStyle}
         descTextStyle={descTextStyle}
         quantity={voteLog.abstained}
-        background={"var(--cl-senate-vote-abstained)"}
+        background="var(--cl-senate-vote-abstained)"
         invertedBoldText
       />
       <QuantityLegend
@@ -58,7 +58,7 @@ const VoteLegendPopupGroup = ({ voteLog }) => {
         boxStyle={boxStyle}
         descTextStyle={descTextStyle}
         quantity={voteLog.absent}
-        background={"var(--cl-senate-vote-absent)"}
+        background="var(--cl-senate-vote-absent)"
         invertedBoldText
       />
       <QuantityLegend
@@ -67,7 +67,7 @@ const VoteLegendPopupGroup = ({ voteLog }) => {
         boxStyle={boxStyle}
         descTextStyle={descTextStyle}
         quantity={voteLog.missing}
-        background={"var(--cl-senate-vote-missing)"}
+        background="var(--cl-senate-vote-missing)"
         invertedBoldText
       />
     </>

--- a/src/components/voteLegend/voteInfoPopupGroup.js
+++ b/src/components/voteLegend/voteInfoPopupGroup.js
@@ -1,0 +1,77 @@
+import React from "react"
+import QuantityLegend from "../quantityLegend"
+import { media } from "../../styles"
+
+const wrapStyle = {
+  fontSize: "1rem",
+  marginTop: "0.6rem",
+  [media(767)]: {
+    fontSize: "1.4rem",
+  },
+}
+
+const boxStyle = {
+  width: "8px",
+  height: "8px",
+}
+
+const descTextStyle = {
+  margin: "0 0.5rem",
+  [media(767)]: {
+    margin: "0 1rem",
+  },
+}
+
+const VoteLegendPopupGroup = ({ voteLog }) => {
+  return (
+    <>
+      <QuantityLegend
+        text="เห็นด้วย"
+        wrapStyle={wrapStyle}
+        boxStyle={boxStyle}
+        descTextStyle={descTextStyle}
+        quantity={voteLog.approve}
+        background={"var(--cl-vote-yes)"}
+        invertedBoldText
+      />
+      <QuantityLegend
+        text="ไม่เห็นด้วย"
+        wrapStyle={wrapStyle}
+        boxStyle={boxStyle}
+        descTextStyle={descTextStyle}
+        quantity={voteLog.disprove}
+        background={"var(--cl-vote-no)"}
+        invertedBoldText
+      />
+      <QuantityLegend
+        text="งดออกเสียง"
+        wrapStyle={wrapStyle}
+        boxStyle={boxStyle}
+        descTextStyle={descTextStyle}
+        quantity={voteLog.abstained}
+        background={"var(--cl-senate-vote-abstained)"}
+        invertedBoldText
+      />
+      <QuantityLegend
+        text="ไม่ลงมติ"
+        wrapStyle={wrapStyle}
+        boxStyle={boxStyle}
+        descTextStyle={descTextStyle}
+        quantity={voteLog.absent}
+        background={"var(--cl-senate-vote-absent)"}
+        invertedBoldText
+      />
+      <QuantityLegend
+        text="ขาด"
+        wrapStyle={wrapStyle}
+        boxStyle={boxStyle}
+        descTextStyle={descTextStyle}
+        quantity={voteLog.missing}
+        background={"var(--cl-senate-vote-missing)"}
+        invertedBoldText
+      />
+    </>
+  )
+}
+
+export default VoteLegendPopupGroup

--- a/src/components/voteLegend/voteSenateGroup.js
+++ b/src/components/voteLegend/voteSenateGroup.js
@@ -21,6 +21,12 @@ const wrapStyle = {
   },
 }
 
+const smallWrapStyle = {
+  display: "flex",
+  justifyContent: "flex-start",
+  fontSize: "1rem",
+}
+
 const boxStyle = {
   width: "8px",
   height: "8px",
@@ -30,6 +36,12 @@ const boxStyle = {
   },
 }
 
+const smallBoxStyle = {
+  width: "3px",
+  height: "10px",
+  marginRight: "0",
+}
+
 const descTextStyle = {
   margin: "0 0.5rem",
   [media(767)]: {
@@ -37,55 +49,60 @@ const descTextStyle = {
   },
 }
 
-const VoteLegendGroup = ({ voteLog }) => {
+const smallDescTextStyle = {
+  margin: "0",
+  marginRight: "0.7rem",
+}
+
+const VoteLegendGroup = ({ voteLog, hasAverageText, isSmallText }) => {
   return (
     <>
-      <div css={styleAvgText}>โดยเฉลี่ย</div>
+      {hasAverageText && <div css={styleAvgText}>โดยเฉลี่ย</div>}
       <QuantityLegend
-        text="เห็นด้วย"
-        wrapStyle={wrapStyle}
-        boxStyle={boxStyle}
-        descTextStyle={descTextStyle}
+        text={!isSmallText ? "เห็นด้วย" : ""}
+        wrapStyle={isSmallText ? smallWrapStyle : wrapStyle}
+        boxStyle={isSmallText ? smallBoxStyle : boxStyle}
+        descTextStyle={isSmallText ? smallDescTextStyle : descTextStyle}
         quantity={voteLog.approve}
         background={"var(--cl-vote-yes)"}
         invertedBoldText
         isPercent
       />
       <QuantityLegend
-        text="ไม่เห็นด้วย"
-        wrapStyle={wrapStyle}
-        boxStyle={boxStyle}
-        descTextStyle={descTextStyle}
+        text={!isSmallText ? "ไม่เห็นด้วย" : ""}
+        wrapStyle={isSmallText ? smallWrapStyle : wrapStyle}
+        boxStyle={isSmallText ? smallBoxStyle : boxStyle}
+        descTextStyle={isSmallText ? smallDescTextStyle : descTextStyle}
         quantity={voteLog.disprove}
         background={"var(--cl-vote-no)"}
         invertedBoldText
         isPercent
       />
       <QuantityLegend
-        text="งดออกเสียง"
-        wrapStyle={wrapStyle}
-        boxStyle={boxStyle}
-        descTextStyle={descTextStyle}
+        text={!isSmallText ? "งดออกเสียง" : ""}
+        wrapStyle={isSmallText ? smallWrapStyle : wrapStyle}
+        boxStyle={isSmallText ? smallBoxStyle : boxStyle}
+        descTextStyle={isSmallText ? smallDescTextStyle : descTextStyle}
         quantity={voteLog.abstained}
         background={"var(--cl-senate-vote-abstained)"}
         invertedBoldText
         isPercent
       />
       <QuantityLegend
-        text="ไม่ลงมติ"
-        wrapStyle={wrapStyle}
-        boxStyle={boxStyle}
-        descTextStyle={descTextStyle}
+        text={!isSmallText ? "ไม่ลงมติ" : ""}
+        wrapStyle={isSmallText ? smallWrapStyle : wrapStyle}
+        boxStyle={isSmallText ? smallBoxStyle : boxStyle}
+        descTextStyle={isSmallText ? smallDescTextStyle : descTextStyle}
         quantity={voteLog.absent}
         background={"var(--cl-senate-vote-absent)"}
         invertedBoldText
         isPercent
       />
       <QuantityLegend
-        text="ไม่ลงคะแนน"
-        wrapStyle={wrapStyle}
-        boxStyle={boxStyle}
-        descTextStyle={descTextStyle}
+        text={!isSmallText ? "ไม่ลงคะแนน" : ""}
+        wrapStyle={isSmallText ? smallWrapStyle : wrapStyle}
+        boxStyle={isSmallText ? smallBoxStyle : boxStyle}
+        descTextStyle={isSmallText ? smallDescTextStyle : descTextStyle}
         quantity={voteLog.missing}
         background={"var(--cl-senate-vote-missing)"}
         invertedBoldText

--- a/src/components/voteLegend/voteSenateGroup.js
+++ b/src/components/voteLegend/voteSenateGroup.js
@@ -1,0 +1,98 @@
+import React from "react"
+import QuantityLegend from "../quantityLegend"
+import { media } from "../../styles"
+
+const styleAvgText = {
+  fontSize: "1rem",
+  marginTop: "0.6rem",
+  marginRight: "1rem",
+  display: "unset",
+  [media(767)]: {
+    display: "none",
+    marginTop: "0",
+  },
+}
+
+const wrapStyle = {
+  fontSize: "1rem",
+  marginTop: "0.6rem",
+  [media(767)]: {
+    fontSize: "1.4rem",
+  },
+}
+
+const boxStyle = {
+  width: "8px",
+  height: "8px",
+  [media(767)]: {
+    width: "15px",
+    height: "15px",
+  },
+}
+
+const descTextStyle = {
+  margin: "0 0.5rem",
+  [media(767)]: {
+    margin: "0 1rem",
+  },
+}
+
+const VoteLegendGroup = ({ voteLog }) => {
+  return (
+    <>
+      <div css={styleAvgText}>โดยเฉลี่ย</div>
+      <QuantityLegend
+        text="เห็นด้วย"
+        wrapStyle={wrapStyle}
+        boxStyle={boxStyle}
+        descTextStyle={descTextStyle}
+        quantity={voteLog.approve}
+        background={"var(--cl-vote-yes)"}
+        invertedBoldText
+        isPercent
+      />
+      <QuantityLegend
+        text="ไม่เห็นด้วย"
+        wrapStyle={wrapStyle}
+        boxStyle={boxStyle}
+        descTextStyle={descTextStyle}
+        quantity={voteLog.disprove}
+        background={"var(--cl-vote-no)"}
+        invertedBoldText
+        isPercent
+      />
+      <QuantityLegend
+        text="งดออกเสียง"
+        wrapStyle={wrapStyle}
+        boxStyle={boxStyle}
+        descTextStyle={descTextStyle}
+        quantity={voteLog.abstained}
+        background={"var(--cl-senate-vote-abstained)"}
+        invertedBoldText
+        isPercent
+      />
+      <QuantityLegend
+        text="ไม่ลงมติ"
+        wrapStyle={wrapStyle}
+        boxStyle={boxStyle}
+        descTextStyle={descTextStyle}
+        quantity={voteLog.absent}
+        background={"var(--cl-senate-vote-absent)"}
+        invertedBoldText
+        isPercent
+      />
+      <QuantityLegend
+        text="ไม่ลงคะแนน"
+        wrapStyle={wrapStyle}
+        boxStyle={boxStyle}
+        descTextStyle={descTextStyle}
+        quantity={voteLog.missing}
+        background={"var(--cl-senate-vote-missing)"}
+        invertedBoldText
+        isPercent
+      />
+    </>
+  )
+}
+
+export default VoteLegendGroup

--- a/src/components/voteLogCard.js
+++ b/src/components/voteLogCard.js
@@ -174,19 +174,19 @@ const VoteLogCard = votelog => {
             text="เห็นด้วย"
             boxSize={8}
             quantity={approve}
-            background={"var(--cl-vote-yes)"}
+            background="var(--cl-vote-yes)"
           />
           <QuantityLegend
             text="ไม่เห็นด้วย"
             boxSize={8}
             quantity={disprove}
-            background={"var(--cl-vote-no)"}
+            background="var(--cl-vote-no)"
           />
           <QuantityLegend
             text="งดออกเสียง"
             boxSize={8}
             quantity={abstained}
-            background={"var(--cl-vote-abstained)"}
+            background="var(--cl-vote-abstained)"
           />
           <QuantityLegend text="ไม่ลงคะแนน" boxSize={8} quantity={absent} />
         </div>

--- a/src/components/voteLogCard.js
+++ b/src/components/voteLogCard.js
@@ -3,9 +3,8 @@ import dayjs from "dayjs"
 import { Link } from "gatsby"
 import { css } from "@emotion/react"
 
-import VoteLogLegend from "./voteLogLegend"
-
 import "../styles/global.css"
+import QuantityLegend from "./quantityLegend"
 
 const VoteLogCard = votelog => {
   const {
@@ -165,11 +164,31 @@ const VoteLogCard = votelog => {
         </div>
         <div
           style={{
+            display: "flex",
+            flexWrap: "wrap",
             padding: "1rem 0",
             fontSize: "14px",
           }}
         >
-          <VoteLogLegend {...votelog} />
+          <QuantityLegend
+            text="เห็นด้วย"
+            boxSize={8}
+            quantity={approve}
+            background={"var(--cl-vote-yes)"}
+          />
+          <QuantityLegend
+            text="ไม่เห็นด้วย"
+            boxSize={8}
+            quantity={disprove}
+            background={"var(--cl-vote-no)"}
+          />
+          <QuantityLegend
+            text="งดออกเสียง"
+            boxSize={8}
+            quantity={abstained}
+            background={"var(--cl-vote-abstained)"}
+          />
+          <QuantityLegend text="ไม่ลงคะแนน" boxSize={8} quantity={absent} />
         </div>
         <h6 style={{ fontSize: "2rem" }}>
           {dayjs(vote_date).format("D.M.YYYY")}

--- a/src/templates/votelog-template.js
+++ b/src/templates/votelog-template.js
@@ -284,19 +284,19 @@ const VotelogPage = ({
               text="เห็นด้วย"
               boxSize={10}
               quantity={votelogYaml.approve}
-              background={"var(--cl-vote-yes)"}
+              background="var(--cl-vote-yes)"
             />
             <QuantityLegend
               text="ไม่เห็นด้วย"
               boxSize={10}
               quantity={votelogYaml.disprove}
-              background={"var(--cl-vote-no)"}
+              background="var(--cl-vote-no)"
             />
             <QuantityLegend
               text="งดออกเสียง"
               boxSize={10}
               quantity={votelogYaml.abstained}
-              background={"var(--cl-vote-abstained)"}
+              background="var(--cl-vote-abstained)"
             />
             <QuantityLegend
               text="ไม่ลงคะแนน"

--- a/src/templates/votelog-template.js
+++ b/src/templates/votelog-template.js
@@ -9,7 +9,10 @@ import Layout from "../components/layout"
 import Seo from "../components/seo"
 import VoterList from "../components/voterList"
 import Waffle from "../components/waffle"
-import VoteLogLegend from "../components/voteLogLegend"
+import QuantityLegend from "../components/quantityLegend"
+
+import cross from "../images/icons/votelog/cross.png"
+
 import { media } from "../styles"
 
 export const query = graphql`
@@ -274,8 +277,38 @@ const VotelogPage = ({
             ...cssSection,
           }}
         >
-          <div css={{ marginBottom: "4rem" }}>
-            <VoteLogLegend {...votelogYaml} />
+          <div
+            css={{ display: "flex", flexWrap: "wrap", marginBottom: "4rem" }}
+          >
+            <QuantityLegend
+              text="เห็นด้วย"
+              boxSize={10}
+              quantity={votelogYaml.approve}
+              background={"var(--cl-vote-yes)"}
+            />
+            <QuantityLegend
+              text="ไม่เห็นด้วย"
+              boxSize={10}
+              quantity={votelogYaml.disprove}
+              background={"var(--cl-vote-no)"}
+            />
+            <QuantityLegend
+              text="งดออกเสียง"
+              boxSize={10}
+              quantity={votelogYaml.abstained}
+              background={"var(--cl-vote-abstained)"}
+            />
+            <QuantityLegend
+              text="ไม่ลงคะแนน"
+              boxSize={10}
+              quantity={votelogYaml.absent}
+            />
+            <QuantityLegend
+              text="ไม่เข้าประชุม"
+              boxSize={8}
+              quantity={votelogYaml.special}
+              imgSrc={cross}
+            />
           </div>
           <Waffle
             data={[


### PR DESCRIPTION
### Description
- Resolve from issue https://github.com/wevisdemo/they-work-for-us/issues/34
- Created base component for legend `QuantityLegend`
- Apply component to `votelog` page and `voteLogCard`. This is not complex one, just replaced `QuantityLegend` with required information and add container styling for vote legends.
- For senate page, I've created component for this page called `senateVoteLegendGroup` with reduced display logic (only handle where it needed to show, either vote percentage tab or grouped tab) since previous code needs to handle both normal vote information and senate vote information.