### PR TITLE
fix(#64,#62): is_active does not get queried in cabinet and votelog pages

### DIFF
--- a/src/components/cabinetMemberSection/index.js
+++ b/src/components/cabinetMemberSection/index.js
@@ -18,6 +18,7 @@ const CabinetMemberSection = () => {
             party
             party_group
             mp_type
+            is_active
             fields {
               slug
             }

--- a/src/components/cabinetMemberSection/index.js
+++ b/src/components/cabinetMemberSection/index.js
@@ -19,6 +19,9 @@ const CabinetMemberSection = () => {
             party_group
             mp_type
             is_active
+            images {
+              url
+            }
             fields {
               slug
             }

--- a/src/templates/votelog-template.js
+++ b/src/templates/votelog-template.js
@@ -73,6 +73,7 @@ export const query = graphql`
         is_mp
         is_senator
         is_cabinet
+        is_active
         mp_type
         mp_list
         mp_province


### PR DESCRIPTION
Close #64 and #62, also fix missing people avatar on `/cabinet` page.