### PR TITLE
Fix incorrect debt and asset number format in people page

### DIFF
--- a/src/templates/people-template.js
+++ b/src/templates/people-template.js
@@ -246,7 +246,7 @@ const PersonFinance = person => (
       <strong>ทรัพย์สิน</strong>{" "}
       {person.asset === null
         ? "ไม่มีข้อมูล"
-        : `${formatNumber(person.asset)} บาท`}
+        : `${formatNumber(person.asset, 2)} บาท`}
     </span>{" "}
     <span>
       <strong>หนี้สิน</strong>{" "}
@@ -256,7 +256,7 @@ const PersonFinance = person => (
         */
       person.debt === null || person.debt === undefined
         ? "ไม่มีข้อมูล"
-        : `${formatNumber(person.debt)} บาท`}
+        : `${formatNumber(person.debt, 2)} บาท`}
     </span>{" "}
     {person.mp_type !== "" &&
       LinkPoliticsAndBusiness(person.name, person.lastname, person.party)}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -31,7 +31,7 @@ export function formatNumber(num, decimalPlaces) {
   } else {
     rawNum = num
   }
-  return rawNum.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, "$1,")
+  return new Intl.NumberFormat("th-TH").format(rawNum)
 }
 
 /**

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -10,11 +10,28 @@ export function formatDate(dt) {
 }
 
 /**
+ * Round number to decimal place.
+ * @param {Number} n number
+ * @param {Number} decimalPlaces rounded result decimal places
+ * @returns rounded number
+ */
+export function roundTo(n, decimalPlaces) {
+  return +(Math.round(n + "e+" + decimalPlaces) + "e-" + decimalPlaces)
+}
+
+/**
  * Format number with thousands
  * @param {Number} num
+ * @param {Number} decimalPlaces
  */
-export function formatNumber(num) {
-  return num.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, "$1,")
+export function formatNumber(num, decimalPlaces) {
+  let rawNum
+  if (decimalPlaces) {
+    rawNum = roundTo(num, decimalPlaces)
+  } else {
+    rawNum = num
+  }
+  return rawNum.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, "$1,")
 }
 
 /**

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -10,28 +10,14 @@ export function formatDate(dt) {
 }
 
 /**
- * Round number to decimal place.
- * @param {Number} n number
- * @param {Number} decimalPlaces rounded result decimal places
- * @returns rounded number
- */
-export function roundTo(n, decimalPlaces) {
-  return +(Math.round(n + "e+" + decimalPlaces) + "e-" + decimalPlaces)
-}
-
-/**
  * Format number with thousands
  * @param {Number} num
  * @param {Number} decimalPlaces
  */
 export function formatNumber(num, decimalPlaces) {
-  let rawNum
-  if (decimalPlaces) {
-    rawNum = roundTo(num, decimalPlaces)
-  } else {
-    rawNum = num
-  }
-  return new Intl.NumberFormat("th-TH").format(rawNum)
+  return new Intl.NumberFormat("th-TH", {
+    maximumFractionDigits: decimalPlaces,
+  }).format(num)
 }
 
 /**


### PR DESCRIPTION
### Description
- Open fix from issue https://github.com/wevisdemo/they-work-for-us/issues/76
- Fix by add round number by required decimal places before format to string.
- Result from fix
![Screenshot 2566-04-11 at 19 51 18](https://user-images.githubusercontent.com/14361087/231168484-6f49e097-d85a-4091-aac1-060365865386.png)
