### PR TITLE
feat: add drop-shadow on nav in party profile page + fix: balance border radius on search box 

### DIFF
--- a/src/components/search/autocomplete.js
+++ b/src/components/search/autocomplete.js
@@ -38,7 +38,7 @@ const Autocomplete = ({ setIsZoneDialog, setSelected, selected, setZones }) => {
               width: "300px",
               height: "5rem",
               border: "3px solid #000000",
-              borderRadius: " 4px 0 0 4px",
+              borderRadius: "4px",
               textAlign: "start",
               cursor: "pointer",
             }),

--- a/src/templates/party-template.js
+++ b/src/templates/party-template.js
@@ -419,6 +419,7 @@ const PartyPage = props => {
           css={{
             display: "flex",
             justifyContent: "space-between",
+            boxShadow: "0px 0px 9px rgba(0, 0, 0, 0.7)",
           }}
         >
           <a href="#voteLogs" css={{ ...cssStickyMenu }}>


### PR DESCRIPTION
From #57 
<img width="1426" alt="Screenshot 2566-04-18 at 19 06 13" src="https://user-images.githubusercontent.com/33986491/232773384-faf4551c-cbed-4cad-b8bd-c6aa62aac31a.png">
<img width="1426" alt="Screenshot 2566-04-18 at 19 06 23" src="https://user-images.githubusercontent.com/33986491/232773402-7a2a3501-c7ac-4ba5-9e84-730d41b4004f.png"> 

And #73 
<img width="353" alt="Screenshot 2566-04-19 at 00 06 34" src="https://user-images.githubusercontent.com/33986491/232852495-ccb0e200-3519-4d3f-ba47-375bfef9ee24.png">

